### PR TITLE
Fix typescript error: XXX is possibly null, Expected 4 arguments, but got 1 or more.

### DIFF
--- a/src/pages/works/webgl-sandbox/points-on-click-by-buffer.vue
+++ b/src/pages/works/webgl-sandbox/points-on-click-by-buffer.vue
@@ -45,7 +45,8 @@ export default Vue.extend({
       const points = [] as number[];
       canvas.addEventListener("mousedown", (event: MouseEvent) => {
         gl.clear(gl.COLOR_BUFFER_BIT);
-        const rect = event.target.getBoundingClientRect();
+        const target = event.target as HTMLCanvasElement;
+        const rect = target.getBoundingClientRect();
         const x = ((event.clientX - rect.left - rect.width / 2) /
           (rect.width / 2)) as number;
         const y = ((rect.height / 2 - (event.clientY - rect.top)) /

--- a/src/pages/works/webgl-sandbox/points-on-click.vue
+++ b/src/pages/works/webgl-sandbox/points-on-click.vue
@@ -44,18 +44,30 @@ export default Vue.extend({
       gl.clear(gl.COLOR_BUFFER_BIT);
       const points = [] as number[][];
       const colors = [] as number[][];
-      canvas.addEventListener("mousedown", (el: MouseEvent) => {
+      canvas.addEventListener("mousedown", (event: MouseEvent) => {
         gl.clear(gl.COLOR_BUFFER_BIT);
-        const rect = el.target.getBoundingClientRect();
-        const x = ((el.clientX - rect.left - rect.width / 2) /
+        const target = event.target as HTMLCanvasElement;
+        const rect = target.getBoundingClientRect();
+        const x = ((event.clientX - rect.left - rect.width / 2) /
           (rect.width / 2)) as number;
-        const y = ((rect.height / 2 - (el.clientY - rect.top)) /
+        const y = ((rect.height / 2 - (event.clientY - rect.top)) /
           (rect.height / 2)) as number;
         points.push([x, y, 0.0]);
         colors.push([Math.abs(x), Math.abs(y), 1.0, 1.0]);
         for (let i = 0; i < points.length; i++) {
-          gl.vertexAttrib3f(a_Position, ...points[i]);
-          gl.uniform4f(u_FragColor, ...colors[i]);
+          gl.vertexAttrib3f(
+            a_Position,
+            points[i][0],
+            points[i][1],
+            points[i][2]
+          );
+          gl.uniform4f(
+            u_FragColor,
+            colors[i][0],
+            colors[i][1],
+            colors[i][2],
+            colors[i][3]
+          );
           gl.drawArrays(gl.POINTS, 0, 1);
         }
       });


### PR DESCRIPTION
## summary
- Fixed TypeScript error of 'xxx is possibly null' for `event.target.getBoundingClientRect()`
- Fixed TypeScript error of 'Expected 4 arguments, but got 1 or more.' for '...points[i]'

### XXX is possibly null
This error occurs when an object is not guaranteed to be certain type.
This was the case when I wrote as following:
```typescript
canvas.addEventListener("mousedown", (event: MouseEvent) => {
  const rect = event.target.getBoundingClientRect(); // => Object is possibly 'null'.
}
```

This error would be fixed by writing either:
```typescript
(event.target as HTMLCanvasElement).getBoundingClientRect()
```
or
```typescript
const target = event.target as HTMLCanvasElement
const rect = target,getBoundingClientRect()
```

### Expected 4 arguments, but got 1 or more.
Spread syntax doesn't seem to be respected on Vetur. Sad.
```typescript
gl.vertexAttrib3f(a_Position, ...points[i]);
```
So you need to write each args respectively as following:
```typescript
gl.vertexAttrib3f(
  a_Position,
  points[i][0],
  points[i][1],
  points[i][2]
);
```